### PR TITLE
DRAFT - Work on replacing dialogic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sounds/speaking/*
 .DS_Store
 mggsave.save
 .import/*
+*.sh

--- a/ActionLevels/Level1/Level1_Forest.tscn
+++ b/ActionLevels/Level1/Level1_Forest.tscn
@@ -144,6 +144,7 @@ charge_shot = ExtResource( 21 )
 
 [node name="LevelEventsManager" parent="." instance=ExtResource( 28 )]
 unique_name_in_owner = true
+debug_trigger_event_number = -1
 
 [node name="Level1_Event1" parent="LevelEventsManager" instance=ExtResource( 27 )]
 enemy_to_spawn = ExtResource( 15 )
@@ -175,6 +176,7 @@ dog = ExtResource( 31 )
 time_until_event_start = 3.0
 
 [node name="Level1_EventBoss" parent="LevelEventsManager" instance=ExtResource( 34 )]
+level1_event1_dialog = ExtResource( 45 )
 
 [node name="Level1_EventEnd" parent="LevelEventsManager" instance=ExtResource( 43 )]
 

--- a/ActionLevels/LevelCreator/Dialog/level1_event1.tres
+++ b/ActionLevels/LevelCreator/Dialog/level1_event1.tres
@@ -1,0 +1,84 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogue_manager/dialogue_resource.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+resource_version = 2
+syntax_version = 2
+raw_text = "~ level1_event1
+
+Have the bird and fish been deployed?
+Yes sir, the girl should be awakening soon.
+What about the boy?
+That will take more time. But once he awakens the girl will have a real challenge.
+Perfect...
+Finally...
+A world where Moonlight Miko will be real!"
+errors = [  ]
+titles = {
+"level1_event1": "2"
+}
+lines = {
+"0": {
+"next_id": "2",
+"text": "level1_event1",
+"type": "title"
+},
+"2": {
+"character": "",
+"next_id": "3",
+"replacements": [  ],
+"text": "Have the bird and fish been deployed?",
+"translation_key": "Have the bird and fish been deployed?",
+"type": "dialogue"
+},
+"3": {
+"character": "",
+"next_id": "4",
+"replacements": [  ],
+"text": "Yes sir, the girl should be awakening soon.",
+"translation_key": "Yes sir, the girl should be awakening soon.",
+"type": "dialogue"
+},
+"4": {
+"character": "",
+"next_id": "5",
+"replacements": [  ],
+"text": "What about the boy?",
+"translation_key": "What about the boy?",
+"type": "dialogue"
+},
+"5": {
+"character": "",
+"next_id": "6",
+"replacements": [  ],
+"text": "That will take more time. But once he awakens the girl will have a real challenge.",
+"translation_key": "That will take more time. But once he awakens the girl will have a real challenge.",
+"type": "dialogue"
+},
+"6": {
+"character": "",
+"next_id": "7",
+"replacements": [  ],
+"text": "Perfect...",
+"translation_key": "Perfect...",
+"type": "dialogue"
+},
+"7": {
+"character": "",
+"next_id": "8",
+"replacements": [  ],
+"text": "Finally...",
+"translation_key": "Finally...",
+"type": "dialogue"
+},
+"8": {
+"character": "",
+"next_id": "",
+"replacements": [  ],
+"text": "A world where Moonlight Miko will be real!",
+"translation_key": "A world where Moonlight Miko will be real!",
+"type": "dialogue"
+}
+}

--- a/ActionLevels/LevelCreator/Dialog/level_event_dialogue.tres
+++ b/ActionLevels/LevelCreator/Dialog/level_event_dialogue.tres
@@ -1,0 +1,59 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogue_manager/dialogue_resource.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+resource_version = 12
+syntax_version = 2
+raw_text = "~ level1_event1
+
+Angel: Bees? Un-BEE-leivable
+
+~ level1_event2
+
+~ level1_event_boss
+Big Bird of Darkness: I am the [shake rate=7 level=15]darkness[/shake]. [wait=1.5] \\nI am the [shake rate=7 level=15]night[/shake]."
+errors = [  ]
+titles = {
+"level1_event1": "2",
+"level1_event2": "6",
+"level1_event_boss": "7"
+}
+lines = {
+"0": {
+"next_id": "2",
+"text": "level1_event1",
+"type": "title"
+},
+"2": {
+"character": "Angel",
+"character_replacements": [  ],
+"next_id": "",
+"replacements": [  ],
+"text": "Bees? Un-BEE-leivable",
+"translation_key": "Bees? Un-BEE-leivable",
+"type": "dialogue"
+},
+"4": {
+"next_id": "",
+"text": "level1_event2",
+"type": "title"
+},
+"6": {
+"next_id": "7",
+"text": "level1_event_boss",
+"type": "title"
+},
+"7": {
+"character": "Big Bird of Darkness",
+"character_replacements": [  ],
+"next_id": "",
+"replacements": [  ],
+"text": "I am the [shake rate=7 level=15]darkness[/shake]. [wait=1.5] 
+I am the [shake rate=7 level=15]night[/shake].",
+"translation_key": "I am the [shake rate=7 level=15]darkness[/shake]. [wait=1.5] 
+I am the [shake rate=7 level=15]night[/shake].",
+"type": "dialogue"
+}
+}

--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event1.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event1.gd
@@ -3,14 +3,17 @@ extends LevelEvent
 onready var enemy_spawner = get_node("%EnemySpawner")
 onready var dialog_layer = get_node("%DialogLayer")
 export var enemy_to_spawn : PackedScene
-onready var new_dialog = Dialogic.start('Level1Event1', '', "res://addons/dialogic/Nodes/DialogNode.tscn", false)
+export var level1_event1_dialog : Resource
+# onready var new_dialog = Dialogic.start('Level1Event1', '', "res://addons/dialogic/Nodes/DialogNode.tscn", false)
 var start_event_timer = Timer.new()
 var wait_after_stopping_spawner_timer = Timer.new()
 
 func _ready():
+	MggDialogue.connect("mgg_dialogue_box_finished", self, "_on_dialogue_box_finished")
 	start_event_timer.set_name("Level1_Event1_start_timer")
 	start_event_timer.connect("timeout", self, "trigger")
 	start_event_timer.set_wait_time(5.0)
+	start_event_timer.one_shot = true
 	wait_after_stopping_spawner_timer.set_name("Level1_Event1_wait_after_stopping_spawner_timer")
 	wait_after_stopping_spawner_timer.connect("timeout", self, "_on_wait_after_stopping_spawner_timer")
 	wait_after_stopping_spawner_timer.set_wait_time(1.5)
@@ -35,12 +38,28 @@ func event_start() -> void:
 		enemy_spawner._direct_spawn_at_position(enemy_to_spawn, Vector2(2200, 699), 300)
 		enemy_spawner._direct_spawn_at_position(enemy_to_spawn, Vector2(2200, 799), 300)
 		enemy_spawner._direct_spawn_at_position(enemy_to_spawn, Vector2(2200, 899), 300)
-		dialog_layer.add_child(new_dialog)
-		#self.get_parent().add_child(new_dialog)
-		end_event()
+		display_dialogue()
 	else:
 		print("enemy spawner is null")
 		
+func display_dialogue():
+	print("Creating dialogue balloon for level1_event1")
+	MggDialogue.create_dialogue_balloon(
+		"level1_event1", 
+		level1_event1_dialog, 
+		self.get_instance_id(), 
+		DataClasses.Placement.LOWER, 
+		DataClasses.CharacterPortrait.AngelIntense,
+		Color(0.12549, 0.619608, 1, 0.25),
+		Color(0.0, 0.0, 0.0, 0.25)
+		)
+
+func _on_dialogue_box_finished(node_id):
+	print("dialogue finished, node_id: ", node_id, ", self.get_instance_id(): ", self.get_instance_id())
+	if self.get_instance_id() == node_id:
+		yield(get_tree().create_timer(2.0), "timeout")
+		end_event()
+
 func end_event() -> void:
 	start_event_timer.stop()
 	enemy_spawner.start_enemy_spawner()

--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventBoss.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventBoss.gd
@@ -18,19 +18,23 @@ var background_boss_spawn_place = Vector2(-500, 700)
 var background_boss_speed = 2000
 export var time_until_event_start = 3.0
 export var debug_mode : bool = false
+export var level1_event1_dialog : Resource
 
 func _ready():
+	MggDialogue.connect("mgg_dialogue_box_finished", self, "_on_dialogue_box_finished")
 	Events.connect("level_event_complete", self, "_on_level_event_complete")
 	Events.connect("background_element_offscreen", self, "_on_background_element_offscreen")
-	boss_dialog.connect("timeline_end", self, "_on_timeline_end")
 	event_number = 6 # last level event
 	boss_warning_tape.connect("warning_finished", self, "_on_warning_finished")
 	event_name = "Level1_EventBoss"
 	if debug_mode:
 		_on_level_event_complete('dummy_event', 5)
 
-func _on_timeline_end(_timeline_name):
-	spawn_boss()
+func _on_dialogue_box_finished(node_id):
+	print("dialogue finished, node_id: ", node_id, ", self.get_instance_id(): ", self.get_instance_id())
+	if self.get_instance_id() == node_id:
+		yield(get_tree().create_timer(2.0), "timeout")
+		spawn_boss()
 	
 func _on_level_event_complete(level_event_name, level_event_number) -> void:
 	if level_event_number == 5:
@@ -57,7 +61,21 @@ func _on_level_event_complete(level_event_name, level_event_number) -> void:
 		
 		start_event_timer.start()
 
+func display_dialogue():
+	print("Creating dialogue balloon for level1_event_boss")
+	MggDialogue.create_dialogue_balloon(
+		"level1_event_boss", 
+		level1_event1_dialog, 
+		self.get_instance_id(), 
+		DataClasses.Placement.LOWER, 
+		DataClasses.CharacterPortrait.None,
+		Color(0.0, 0.0, 0.0, 1.0),
+		Color(0.3, 0.1, 0.5, 1.0)
+		)
+
 func trigger() -> void:
+	print("triggering boss event")
+	print("enemy spawner is ", enemy_spawner)
 	if enemy_spawner != null:
 		Events.emit_signal("level_event_lock", event_name, event_number)
 		enemy_spawner.stop_enemy_spawner()
@@ -77,10 +95,11 @@ func spawn_boss():
 	enemy_spawner._direct_spawn_boss_at_position(boss, Vector2(1510, 620), 0)
 
 func _on_warning_finished():
-	dialog_layer.add_child(boss_dialog)
+	#dialog_layer.add_child(boss_dialog)
+	display_dialogue()
 
 func event_start() -> void:
-
+	print("starting event - boss")
 	if boss_background_to_spawn != null:
 		boss_background_to_spawn.scale.x = 0.65
 		boss_background_to_spawn.scale.y = 0.65

--- a/ActionLevels/LevelCreator/LevelEvents/LevelEventsManager.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/LevelEventsManager.gd
@@ -3,11 +3,14 @@ extends Node
 var completed_events_map = {}
 var currently_running_event = -1
 onready var total_events = self.get_children().size()
-#onready var enemy_spawner = get_node("%EnemySpawner")
+export var debug_trigger_event_number := 6
 
 func _ready():
 	Events.connect("level_event_lock", self, "_on_currently_running_event")
 	Events.connect("level_event_complete", self, "_on_level_event_complete")
+	if debug_trigger_event_number > 0:
+		disable_all_event_timers()
+		call_deferred("debug_trigger_event", debug_trigger_event_number)
 
 func _on_currently_running_event(level_event_name, level_event_number):
 	currently_running_event = level_event_number
@@ -24,5 +27,13 @@ func get_currently_running_event():
 func completed_events():
 	return completed_events_map
 
-#func _process(delta):
-#	print("an event is running ", get_is_event_running(), " the event is ", get_currently_running_event())
+func debug_trigger_event(event_number: int):
+	for child in get_children():
+		if child.event_number == event_number:
+			child.trigger()
+			break
+
+func disable_all_event_timers():
+	for child in get_children():
+		if child.has_method("get") and child.get("start_event_timer") != null:
+			child.start_event_timer.stop()

--- a/Autoload/MggDialogue.gd
+++ b/Autoload/MggDialogue.gd
@@ -6,12 +6,22 @@ signal change_character_portrait(portrait_name)
 var node_id_in_use = -1
 var current_dialogue_creator_node
 
-func create_dialogue_balloon(title: String, dialogue_resource: Resource, node_id: int, placement: int = DataClasses.Placement.LOWER, initial_character_portrait := DataClasses.CharacterPortrait.None):
+func create_dialogue_balloon(
+	title: String, 
+	dialogue_resource: Resource,
+	node_id: int,
+	placement: int = DataClasses.Placement.LOWER,
+	initial_character_portrait := DataClasses.CharacterPortrait.None,
+	dialogue_box_colour := Color(0.12549, 0.619608, 1, 1),
+	dialogue_border_colour := Color(0.0, 0.0, 0.0, 1.0)
+	):
 	var dialogue_creator = load("res://DialogBox/DialogueCreator.tscn").instance()
 	dialogue_creator.title = title
 	dialogue_creator.dialogue_resource = dialogue_resource
 	dialogue_creator.placement = placement
 	dialogue_creator.character_portrait = initial_character_portrait
+	dialogue_creator.dialogue_box_colour = dialogue_box_colour
+	dialogue_creator.dialogue_border_colour = dialogue_border_colour
 	dialogue_creator.connect("dialogue_box_finished", self, "_on_dialogue_box_finished")
 	node_id_in_use = node_id
 	#get_tree().current_scene.add_child(dialogue_creator)

--- a/Cutscenes/Dialog/intro.tres
+++ b/Cutscenes/Dialog/intro.tres
@@ -1,0 +1,84 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogue_manager/dialogue_resource.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+resource_version = 4
+syntax_version = 2
+raw_text = "~ intro
+
+Have the bird and fish been deployed?
+Yes sir, the girl should be awakening soon.
+What about the boy?
+That will take more time. But once he awakens the girl will have a real challenge.
+Perfect...
+Finally...
+A world where Moonlight Miko will be real!"
+errors = [  ]
+titles = {
+"intro": "2"
+}
+lines = {
+"0": {
+"next_id": "2",
+"text": "intro",
+"type": "title"
+},
+"2": {
+"character": "",
+"next_id": "3",
+"replacements": [  ],
+"text": "Have the bird and fish been deployed?",
+"translation_key": "Have the bird and fish been deployed?",
+"type": "dialogue"
+},
+"3": {
+"character": "",
+"next_id": "4",
+"replacements": [  ],
+"text": "Yes sir, the girl should be awakening soon.",
+"translation_key": "Yes sir, the girl should be awakening soon.",
+"type": "dialogue"
+},
+"4": {
+"character": "",
+"next_id": "5",
+"replacements": [  ],
+"text": "What about the boy?",
+"translation_key": "What about the boy?",
+"type": "dialogue"
+},
+"5": {
+"character": "",
+"next_id": "6",
+"replacements": [  ],
+"text": "That will take more time. But once he awakens the girl will have a real challenge.",
+"translation_key": "That will take more time. But once he awakens the girl will have a real challenge.",
+"type": "dialogue"
+},
+"6": {
+"character": "",
+"next_id": "7",
+"replacements": [  ],
+"text": "Perfect...",
+"translation_key": "Perfect...",
+"type": "dialogue"
+},
+"7": {
+"character": "",
+"next_id": "8",
+"replacements": [  ],
+"text": "Finally...",
+"translation_key": "Finally...",
+"type": "dialogue"
+},
+"8": {
+"character": "",
+"next_id": "",
+"replacements": [  ],
+"text": "A world where Moonlight Miko will be real!",
+"translation_key": "A world where Moonlight Miko will be real!",
+"type": "dialogue"
+}
+}

--- a/Cutscenes/Intro.gd
+++ b/Cutscenes/Intro.gd
@@ -1,15 +1,17 @@
 extends Node2D
 
-onready var intro_cutscene_dialogue = Dialogic.start('Cutscenes/IntroCutscene')
 var tv_sound_finished = false
+export var intro_dialog : Resource
 
 func _ready():
+	MggDialogue.connect("mgg_dialogue_box_finished", self, "_on_dialogue_box_finished")
 	$TVTurnOn.play()
 	$CanvasLayer/VHS.set_modulate(Color(1,1,1,0))
 	$AyyLmao.set_modulate(Color(1,1,1,0))
 	$AyyLmao2.set_modulate(Color(1,1,1,0))
-	
-	#intro_cutscene_dialogue.connect("")
+
+func display_dialogue():
+	MggDialogue.create_dialogue_balloon("intro", intro_dialog, self.get_parent().get_instance_id(), DataClasses.Placement.LOWER, DataClasses.CharacterPortrait.None)
 
 func _process(delta):
 	if tv_sound_finished:
@@ -19,4 +21,4 @@ func _process(delta):
 
 func _on_TVTurnOn_finished():
 	tv_sound_finished = true
-	self.add_child(intro_cutscene_dialogue)
+	display_dialogue()

--- a/Cutscenes/Intro.tscn
+++ b/Cutscenes/Intro.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://ActionLevels/backgrounds/VHS.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Cutscenes/AyyLmao_SpriteOne.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Cutscenes/Intro.gd" type="Script" id=3]
 [ext_resource path="res://sounds/cutscenes/crt-turn-on.mp3" type="AudioStream" id=4]
+[ext_resource path="res://Cutscenes/Dialog/intro.tres" type="Resource" id=5]
 
 [sub_resource type="Shader" id=1]
 code = "/*
@@ -262,6 +263,7 @@ shader_param/vignette_opacity = 0.5
 
 [node name="Intro" type="Node2D"]
 script = ExtResource( 3 )
+intro_dialog = ExtResource( 5 )
 
 [node name="AyyLmao" parent="." instance=ExtResource( 2 )]
 modulate = Color( 1, 1, 1, 0.196078 )

--- a/DialogBox/DialogueContainer.gd
+++ b/DialogBox/DialogueContainer.gd
@@ -20,6 +20,8 @@ var placement_dictionary = {
 
 var placement = DataClasses.Placement.LOWER
 var character_portrait = DataClasses.CharacterPortrait.None
+var dialogue_box_colour := Color(0.12549, 0.619608, 1.0, 1.0)
+var dialogue_border_colour := Color(0.0, 0.0, 0.0, 1.0)
 
 var dialogue
 var is_waiting_for_input: bool = false
@@ -43,13 +45,16 @@ func add_dialogue():
 		return
 
 	self.dialogue = dialogue
-	if dialogue.character == "":
+	if character_portrait == DataClasses.CharacterPortrait.None:
 		margin_container.add_constant_override("margin_right", 10)
 		portrait.hide()
-		character_title.hide()
 	else:
 		portrait.show()
 		margin_container.add_constant_override("margin_right", 125)
+
+	if dialogue.character == "":
+		character_title.hide()
+	else:
 		character_title.bbcode_text = dialogue.character
 
 		dialogue_label.rect_size.x = dialogue_label.get_parent().rect_size.x
@@ -99,7 +104,13 @@ func container_placement():
 func set_character_portrait():
 	portrait.display_character(character_portrait)
 
+func set_stylebox_colour():
+	var stylebox = dialogue_main_window.get_stylebox("panel")
+	stylebox.bg_color = dialogue_box_colour
+	stylebox.border_color = dialogue_border_colour
+
 func _ready() -> void:
+	set_stylebox_colour()
 	set_character_portrait()
 	container_placement()
 	dialogue_label.connect("arriving_characer", self, "_on_arriving_character")

--- a/DialogBox/DialogueContainer.tscn
+++ b/DialogBox/DialogueContainer.tscn
@@ -139,7 +139,6 @@ texture = ExtResource( 4 )
 
 [node name="DialogueAudio" type="AudioStreamPlayer" parent="."]
 unique_name_in_owner = true
-stream = ExtResource( 8 )
 volume_db = -10.0
 pitch_scale = 0.7
 

--- a/DialogBox/DialogueCreator.gd
+++ b/DialogBox/DialogueCreator.gd
@@ -9,6 +9,9 @@ var has_connected_signal = false
 var enable_create_dialogue_balloon = true
 export var placement: int = DataClasses.Placement.LOWER
 export(DataClasses.CharacterPortrait) var character_portrait := DataClasses.CharacterPortrait.None
+export var dialogue_box_colour := Color(0.12549, 0.619608, 1, 1)
+export var dialogue_border_colour := Color(0.0, 0.0, 0.0, 1.0)
+
 onready var timer = get_node("%Timer")
 
 func _ready():
@@ -26,6 +29,7 @@ func show_dialogue(key: String) -> void:
 		var new_dialogue_bubble = load("res://DialogBox/DialogueContainer.tscn").instance()
 		new_dialogue_bubble.placement = placement
 		new_dialogue_bubble.character_portrait = character_portrait
+		new_dialogue_bubble.dialogue_box_colour = dialogue_box_colour
 		new_dialogue_bubble.set_dialogue(dialogue)
 		self.add_child(new_dialogue_bubble)
 	show_dialogue(yield(self.get_child(1), "actioned"))


### PR DESCRIPTION
Don't merge this yet. Still in progress, needs testing.

- Replace some instances of dialogic with dialogue manager in Level1_Event1 and Level1_EventBoss and Intro (although this is not actually the intro anymore, needs a name change)
- Add customisation to the dialogue manager box by allowing the developer to pass in the colour the box and its border should be
- Fix a bug where the dialogue box portrait still displays even when it's explicitly set to none
- Separate portrait and character title logic
- Add some debug functionality to LevelEventManager for easier testing
- Move some dialogic resources over to dialogue manager resources