### PR TITLE
[Bug fix] - Fixes a bug where button mashing start crashes the game

### DIFF
--- a/Autoload/SceneManager.gd
+++ b/Autoload/SceneManager.gd
@@ -9,6 +9,7 @@ onready var tween = get_node("%Tween")
 onready var loading_text = get_node("%LoadingText")
 onready var spinning_star = get_node("%SpinningStar")
 
+var is_loading : bool = false
 var loader: ResourceInteractiveLoader
 var loading_complete: bool = false
 var loading_dots_timer: float = 0.0
@@ -58,8 +59,8 @@ func _transition_to_next_scene(_next_scene, battle_dialogue_intro: bool = false)
 	yield(tween, "tween_all_completed")
 	
 	var scene_path = get_scene_path(_next_scene)
-	print("scene path ", scene_path)
-	if scene_path:
+	if scene_path and !is_loading:
+		is_loading = true
 		yield(_load_scene_async(scene_path), "completed")
 
 func _load_scene_async(scene_path: String):
@@ -78,9 +79,7 @@ func _load_scene_async(scene_path: String):
 		
 		if err == ERR_FILE_EOF:
 			loading_complete = true
-			#color_rect.visible = false
-			#spinning_star.visible = false
-			#loading_text.visible = false
+			is_loading = false
 			var resource = loader.get_resource()
 			loader = null
 			

--- a/Menus/MainMenu.gd
+++ b/Menus/MainMenu.gd
@@ -14,6 +14,7 @@ onready var room_button : Button = get_node("%RoomButton")
 onready var quit_button : Button = get_node("%QuitButton")
 
 var has_completed_demo : bool = false
+var button_pressed : bool = false
 
 func _ready():
 	tween.interpolate_property(camera, "position",
@@ -36,7 +37,9 @@ func _process(delta):
 		title_screen_animation.playback_speed = 10
 
 func _on_StartButton_pressed():
-	send_to_level("Level1")
+	if !button_pressed:
+		button_pressed = true
+		send_to_level("Level1")
 
 func _on_OptionsButton_pressed():
 	$MenuLayer/VBoxContainer.visible = false
@@ -79,11 +82,8 @@ func _on_RoomButton_focus_entered():
 func _on_RoomButton_focus_exited():
 	star_select_room.visible = false
 
-
-
 func _on_QuitButton_mouse_entered():
 	quit_button.grab_focus()
-	
 
 func _on_RoomButton_mouse_entered():
 	if not room_button.disabled:
@@ -91,3 +91,4 @@ func _on_RoomButton_mouse_entered():
 
 func _on_StartButton_mouse_entered():
 	start_button.grab_focus()
+


### PR DESCRIPTION
- When a scene is being loaded don't allow another scene to be loaded simultaneously (reject future requests until loading is complete)