### PR TITLE
Skip Loading to Game Over sceen

### DIFF
--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventEnd.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventEnd.gd
@@ -43,7 +43,7 @@ func event_start() -> void:
 	print("Starting final event.")
 	var saved_dogs_for_level = {1 : collected_dogs}
 	Events.save_game(1, saved_dogs_for_level)
-	Events.emit_signal("transition_to_scene", "DemoEndCredits")
+	Events.emit_signal("transition_to_scene", "DemoEndCredits", false)
 	
 func end_event() -> void:
 	Events.emit_signal("level_event_complete", event_name, event_number)

--- a/ActionLevels/Room/LevelSelect.gd
+++ b/ActionLevels/Room/LevelSelect.gd
@@ -86,20 +86,20 @@ func _on_Level1_gui_input(event):
 	if event is InputEventMouseButton:
 		if event.get_button_index() == BUTTON_LEFT and event.pressed:
 			print("transition to level 1")
-			Events.emit_signal("transition_to_scene", "Level1")
+			Events.emit_signal("transition_to_scene", "Level1", false)
 
 
 
 func _on_Level2_gui_input(event):
 	if event is InputEventMouseButton:
 		if event.get_button_index() == BUTTON_LEFT and event.pressed:
-			Events.emit_signal("transition_to_scene", "Level2")
+			Events.emit_signal("transition_to_scene", "Level2", false)
 
 
 func _on_Level3_gui_input(event):
 	if event is InputEventMouseButton:
 		if event.get_button_index() == BUTTON_LEFT and event.pressed:
-			Events.emit_signal("transition_to_scene", "Level3")
+			Events.emit_signal("transition_to_scene", "Level3", false)
 
 
 

--- a/Autoload/Events.gd
+++ b/Autoload/Events.gd
@@ -85,7 +85,7 @@ func transition_to_new_scene(next_scene):
 	
 func go_to_game_over():
 	print("transition to game over screen")
-	self.emit_signal("transition_to_scene", "GameOver")
+	self.emit_signal("transition_to_scene", "GameOver", true)
 
 
 onready var enemyPaths = {

--- a/Autoload/SceneManager.gd
+++ b/Autoload/SceneManager.gd
@@ -44,16 +44,23 @@ func get_scene_path(scene_name):
 	else:
 		print("Scene not present in action level list")
 
-func _transition_to_next_scene(_next_scene, battle_dialogue_intro: bool = false):
+func _transition_to_next_scene(_next_scene, skip_loading_screen := false):
 	if loader != null:
 		print("Scene loading already in progress, ignoring request for ", _next_scene)
 		return
+	
 	color_rect.show()
-	spinning_star.visible = true
-	loading_text.visible = true
-	loading_dots_timer = 0.0
-	loading_dots_count = 1
-	loading_text.text = "Loading."
+	
+	if skip_loading_screen:
+		spinning_star.visible = false
+		loading_text.visible = false
+	else:
+		spinning_star.visible = true
+		loading_text.visible = true
+		loading_dots_timer = 0.0
+		loading_dots_count = 1
+		loading_text.text = "Loading."
+	
 	tween.interpolate_property(color_rect, "modulate:a", 0, 1, fade_duration)
 	tween.start()
 	yield(tween, "tween_all_completed")
@@ -61,7 +68,10 @@ func _transition_to_next_scene(_next_scene, battle_dialogue_intro: bool = false)
 	var scene_path = get_scene_path(_next_scene)
 	if scene_path and !is_loading:
 		is_loading = true
-		yield(_load_scene_async(scene_path), "completed")
+		if skip_loading_screen:
+			yield(_load_scene_fast(scene_path), "completed")
+		else:
+			yield(_load_scene_async(scene_path), "completed")
 
 func _load_scene_async(scene_path: String):
 	loading_complete = false
@@ -97,6 +107,18 @@ func _load_scene_async(scene_path: String):
 			break
 		
 		yield(get_tree(), "idle_frame")
+
+func _load_scene_fast(scene_path: String):
+	var resource = load(scene_path)
+	is_loading = false
+	
+	if resource and resource is PackedScene:
+		get_tree().change_scene_to(resource)
+		tween.interpolate_property(color_rect, "modulate:a", 1.0, 0.0, fade_duration)
+		tween.start()
+		yield(tween, "tween_all_completed")
+	else:
+		print("Failed to load scene resource")
 
 func _update_loading_progress(progress: float):
 	loading_dots_timer += get_process_delta_time()

--- a/HUD/PauseMenu.gd
+++ b/HUD/PauseMenu.gd
@@ -101,7 +101,7 @@ func _on_QuitBtn_pressed():
 
 func _on_BackBtn_pressed():
 	self.is_paused = false
-	Events.emit_signal("transition_to_scene", "ComputerScreen")
+	Events.emit_signal("transition_to_scene", "ComputerScreen", false)
 
 func _on_ResumeBtn_focus_entered():
 	spinny_star_resume.visible = true

--- a/HUD/PauseMenuGameplay.gd
+++ b/HUD/PauseMenuGameplay.gd
@@ -98,11 +98,11 @@ func _on_ResumeBtn_pressed():
 
 func _on_QuitBtn_pressed(): #Should return to title screen!
 	self.is_paused = false
-	Events.emit_signal("transition_to_scene", "TitleScreen")
+	Events.emit_signal("transition_to_scene", "TitleScreen", false)
 
 func _on_BackBtn_pressed():	 #Should restart scene
 	self.is_paused = false
-	Events.emit_signal("transition_to_scene", "Level1")
+	Events.emit_signal("transition_to_scene", "Level1", false)
 
 func _on_ResumeBtn_focus_entered():
 	spinny_star_resume.visible = true

--- a/Menus/DemoEndCredits.gd
+++ b/Menus/DemoEndCredits.gd
@@ -35,7 +35,7 @@ func _on_BackButton_pressed():
 
 func _on_TitleButton_pressed():
 	#TODO: it dont work, and I don't know why :T
-	Events.emit_signal("transition_to_scene", "TitleScreen")
+	Events.emit_signal("transition_to_scene", "TitleScreen", false)
 
 
 func _on_NextButton_pressed():

--- a/Menus/GameOver.gd
+++ b/Menus/GameOver.gd
@@ -21,11 +21,11 @@ func _on_RetryButton_pressed():
 		determined_sprite.show()
 		yield(get_tree().create_timer(0.5), "timeout")
 		
-		Events.emit_signal("transition_to_scene", "Level1")
+		Events.emit_signal("transition_to_scene", "Level1", false)
 
 func _on_QuitButton_pressed():
 	if faded_in:
-		Events.emit_signal("transition_to_scene", "TitleScreen")
+		Events.emit_signal("transition_to_scene", "TitleScreen", false)
 
 
 func _on_AnimationPlayer_animation_finished(anim_name):

--- a/Menus/MainMenu.gd
+++ b/Menus/MainMenu.gd
@@ -52,7 +52,7 @@ func _on_QuitButton_pressed():
 	get_tree().quit()
 
 func send_to_level(level_name: String):
-	Events.emit_signal("transition_to_scene", level_name)
+	Events.emit_signal("transition_to_scene", level_name, false)
 
 func _on_StartButton_focus_entered():
 	star_select_start.visible = true


### PR DESCRIPTION
- Allow SceneManager to skip the loading screen when moving to other scenes (used in transition to GameOver screen)
- It will still fade to black and then fade out again so it still looks nice