### PR TITLE
Fix enemy explosion speed

### DIFF
--- a/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
+++ b/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
@@ -101,11 +101,11 @@ func call_death(count_as_regular_death: bool):
 	if is_instance_valid(area2d):
 		active_death_explosion_node = death_explosion.instance()
 		active_death_explosion_node.add_to_group("death_explosion")
-		var death_position = area2d.position
 		var death_global_position = area2d.global_position
-		active_death_explosion_node.position = death_position
+		active_death_explosion_node.global_position = death_global_position
+		active_death_explosion_node.scale = area2d.scale
 		active_death_explosion_node.connect("animation_finished", self, "_on_explosion_finished")
-		active_death_explosion_node.scroll_speed = initial_scroll_speed
+		self.get_parent().add_child(active_death_explosion_node)
 		area2d.add_child(active_death_explosion_node)
 		sprite.visible = false
 		active_death_explosion_node.play("default", false)

--- a/ActionLevels/LevelCreator/Enemies/EnemyAssets/AnimatedEnemyExplosion.gd
+++ b/ActionLevels/LevelCreator/Enemies/EnemyAssets/AnimatedEnemyExplosion.gd
@@ -6,7 +6,7 @@ func _ready():
 	pass
 
 func _process(delta):
-	self.position.x -= delta * 1.25 * scroll_speed
+	self.position.x -= delta * scroll_speed
 
 func _on_AnimatedEnemyExplosion_animation_finished():
 	self.queue_free()


### PR DESCRIPTION
Issue was that the enemy explosion was tied to the enemy node which meant it would move at its own speed + the enemy's speed. Instead we place it in the main tree outside of the enemy so it moves on its own and isn't a part of the enemy.