### PR TITLE
Wait for idle frame so physics process to allow standing animation to

### DIFF
--- a/ActionLevels/Level1/Level1_Forest.tscn
+++ b/ActionLevels/Level1/Level1_Forest.tscn
@@ -120,7 +120,6 @@ volume_db = -30.0
 
 [node name="Player" parent="." instance=ExtResource( 3 )]
 position = Vector2( 247, 860 )
-debug_mode = true
 gunshot = ExtResource( 20 )
 charge_shot = ExtResource( 21 )
 

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -140,7 +140,15 @@ func _ready():
 	staff_forward.frame = 0
 	staff_up.frame = 0
 	staff_down.frame = 0
-	travel_to_animation("Run")
+	
+	# Wait one frame for physics to initialize
+	yield(get_tree(), "idle_frame")
+	
+	if is_on_floor() and is_standing:
+		travel_to_animation("JustStanding")
+	else:
+		travel_to_animation("Run")
+	
 	setup_debug_canvas(debug_mode)
 
 func _on_in_battle_dialogue(_in_battle_dialogue, _enemy_name):


### PR DESCRIPTION
Fixes a lil annoying bug where the player falls at the start of the game.

I thiiiink this happens because the physics haven't processed yet on the first frame so the `is_on_floor` check returns false. This adds a wait for the first frame to ensure the physics have started.