### PR TITLE
Small fixes to enemy explosion and boss warning

### DIFF
--- a/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
+++ b/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
@@ -106,7 +106,6 @@ func call_death(count_as_regular_death: bool):
 		active_death_explosion_node.scale = area2d.scale
 		active_death_explosion_node.connect("animation_finished", self, "_on_explosion_finished")
 		self.get_parent().add_child(active_death_explosion_node)
-		area2d.add_child(active_death_explosion_node)
 		sprite.visible = false
 		active_death_explosion_node.play("default", false)
 		spawn_possible_collectible(death_global_position)

--- a/ActionLevels/LevelCreator/Props/BossWarningTape.gd
+++ b/ActionLevels/LevelCreator/Props/BossWarningTape.gd
@@ -43,4 +43,6 @@ func _on_Timer_timeout():
 	animation_player.play_backwards("boss_approaching")
 	yield(animation_player,"animation_finished")
 	color_rect_tween.stop_all()
+	background_layer.visible = false
+	visible_elements_layer.visible = false
 	emit_signal("warning_finished")


### PR DESCRIPTION
Small fix to enemy explosion being parented to the wrong node
Small fix to hiding the warning tape fully when the animation ends and hiding it from view in the editor