### PR TITLE
Fix dog logic in MainMenu

### DIFF
--- a/Menus/MainMenu.gd
+++ b/Menus/MainMenu.gd
@@ -6,7 +6,6 @@ onready var star_select_start = get_node("%StarSelectStart")
 onready var star_select_quit = get_node("%StarSelectQuit")
 onready var star_select_room = get_node("%StarSelectRoom")
 onready var title_screen_animation = get_node("%TitleScreenAnimation")
-onready var all_dogs_completion_message = get_node("%AllDogsCompletion")
 onready var camera = get_node("%Camera2D")
 onready var tween = get_node("%Tween")
 
@@ -22,14 +21,8 @@ var has_completed_demo : bool = false
 var button_pressed : bool = false
 var first_focus : bool = true
 
-var all_dogs_collected : bool = false
-
 func _ready():
 	cheat_code_detection = []
-	all_dogs_completion_message.connect("all_dogs_message_finished", self, "_on_all_dogs_finished_message")
-	all_dogs_collected = Events.COLLECTED_DOGS.size() >= 3
-	if all_dogs_collected:
-		all_dogs_collected_message_display()
 	tween.interpolate_property(camera, "position",
 		camera.position, Vector2(961, 540), 2,
 		Tween.TRANS_SINE, Tween.EASE_IN)
@@ -37,7 +30,8 @@ func _ready():
 	SceneManager.visible = true
 	var directory = Directory.new()
 	var fileExists = directory.file_exists(Events.SAVE_FILE_LOCATION)
-	if !all_dogs_collected:
+	
+	if !Events.dogs_complete:
 		room_button.text = "???"
 		room_button.disabled = true
 	else:
@@ -45,10 +39,6 @@ func _ready():
 		room_button.disabled = false
 	AudioManager.playSFX("twinkle")
 	AudioManager.play_music("main_menu")
-	
-
-func all_dogs_collected_message_display():
-	all_dogs_completion_message.display_message()
 
 func _process(delta):
 	if (title_screen_animation.is_playing() or tween.is_active()) and Input.is_action_just_pressed("ui_accept"):


### PR DESCRIPTION
Fixes a bug where if you had already unlocked the bedroom and then started the level, paused and returned to title you'd lose access to the button. This happened because we were checking the global array for dogs (which gets reset when a level is started again) rather than the `dogs_complete` variable.