### PR TITLE
[Balance change] Increase timer for event 2 from 10 seconds to 20

### DIFF
--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event2.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event2.gd
@@ -8,7 +8,7 @@ onready var spawn_enemies_timer = Timer.new()
 onready var spawn_platforms_timer = Timer.new()
 onready var spawn_background_enemies_timer = Timer.new()
 onready var wait_after_stopping_spawner_timer = Timer.new()
-export var time_until_event_start = 10.0
+export var time_until_event_start = 20.0
 var num_background_enemies_spawned = 0
 var num_enemies_spawned = 0
 var num_platforms_spawned = 0
@@ -36,8 +36,6 @@ func _ready():
 	_preload_all_objects()
 
 func _preload_all_objects():
-	print("Level1_Event2: Preloading objects...")
-	
 	for i in range(3):
 		var platform = platform_to_spawn.instance()
 		platform.scroll_speed = platform_scroll_speed
@@ -58,9 +56,6 @@ func _preload_all_objects():
 		enemy.visible = false
 		enemy.set_process(false)
 		preloaded_enemies.append(enemy)
-	
-	print("Level1_Event2: Preloading complete - ", preloaded_platforms.size(), " platforms, ", 
-		  preloaded_background_enemies.size(), " bg enemies, ", preloaded_enemies.size(), " enemies")
 
 func _spawn_preloaded_platform():
 	if preloaded_platforms.size() > 0:
@@ -69,9 +64,8 @@ func _spawn_preloaded_platform():
 		platform.visible = true
 		platform.set_process(true)
 		platform_spawner.cached_parent_node.add_child(platform)
-		print("Level1_Event2: Spawned preloaded platform at ", platform.position)
 	else:
-		print("Level1_Event2: No more preloaded platforms available!")
+		print_debug("Level1_Event2: No more preloaded platforms available!")
 
 func _spawn_preloaded_background_enemy():
 	if preloaded_background_enemies.size() > 0:
@@ -84,9 +78,8 @@ func _spawn_preloaded_background_enemy():
 		bg_enemy.visible = true
 		bg_enemy.set_process(true)
 		enemy_spawner.level_background.get_node_or_null('BackForestBackground').add_child(bg_enemy)
-		print("Level1_Event2: Spawned preloaded background enemy")
 	else:
-		print("Level1_Event2: No more preloaded background enemies available!")
+		print_debug("Level1_Event2: No more preloaded background enemies available!")
 
 func _spawn_preloaded_enemy():
 	if preloaded_enemies.size() > 0:
@@ -97,9 +90,8 @@ func _spawn_preloaded_enemy():
 		enemy.visible = true
 		enemy.set_process(true)
 		enemy_spawner.get_parent().call_deferred("add_child", enemy)
-		print("Level1_Event2: Spawned preloaded enemy at ", enemy.position)
 	else:
-		print("Level1_Event2: No more preloaded enemies available!")
+		print_debug("Level1_Event2: No more preloaded enemies available!")
 
 func _on_level_event_complete(level_event_name, level_event_number):
 	if level_event_number == 1:


### PR DESCRIPTION
This is a slight balance change to help the player have the opportunity to achieve a better score.

Event 2 is when 20 bees fly in the background and then directly at the player. These bees are basically unkillable unless you have a charge shot because they move so fast. A smart player who is familiar with the mechanics will save their charge shot for this event and get an easy 200 points.

However, because the event started so early (10 seconds after the previous event) it wasn't always guaranteed the user would have gained enough energy to use their charge shot. By increasing the time until the event triggers this should guarantee that a smart player can kill enough enemies before the event starts to ensure they have the charge shot ready.