### PR TITLE
[Bug fix] - Put projectiles on current scene and not root scene

### DIFF
--- a/ActionLevels/Level1/Level1_Forest.gd
+++ b/ActionLevels/Level1/Level1_Forest.gd
@@ -37,6 +37,7 @@ func _ready():
 	Events.connect("boss_spawned", self, "_on_boss_spawn")
 	Events.connect("collected_all_dogs", self, "_on_all_dogs_collected")
 	Events.emit_signal("background_moving_enabled", false)
+	Events.emit_signal("player_invincible", true)
 	Events.emit_signal("player_standing", true)
 	Events.COLLECTED_DOGS = {}
 
@@ -66,6 +67,7 @@ func _on_confirm_level_start():
 	platform_spawner.start_platform_spawner()
 	Events.emit_signal("background_moving_enabled", true)
 	Events.emit_signal("player_standing", false)
+	Events.emit_signal("player_invincible", false)
 	Events.emit_signal("fall_down_ui")
 	self.emit_signal("level_start")
 	add_initial_background_element()

--- a/ActionLevels/LevelCreator/Bosses/BigBird/BigBird_logic.gd
+++ b/ActionLevels/LevelCreator/Bosses/BigBird/BigBird_logic.gd
@@ -112,7 +112,7 @@ func _on_fire_rate_timeout():
 	for s in rotator.get_children():
 		var bullet = lil_bird_bullet.instance()
 		bullet.speed = projectile_speed
-		get_tree().get_root().add_child(bullet)
+		get_tree().current_scene.add_child(bullet)
 		bullet.position = s.global_position
 		bullet.rotation = s.global_rotation
 

--- a/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
+++ b/ActionLevels/LevelCreator/Enemies/BasicEnemy.gd
@@ -86,7 +86,7 @@ func spawn_possible_collectible(death_position: Vector2):
 		var _collectible_to_spawn = droppables[randi() % droppables.size()].instance()
 		_collectible_to_spawn.scroll_speed = 250
 		_collectible_to_spawn.position = death_position
-		get_tree().get_root().add_child(_collectible_to_spawn)
+		get_tree().current_scene.add_child(_collectible_to_spawn)
 
 
 func call_death(count_as_regular_death: bool):

--- a/ActionLevels/LevelCreator/Enemies/BroBun/BroBunProjectile.gd
+++ b/ActionLevels/LevelCreator/Enemies/BroBun/BroBunProjectile.gd
@@ -15,7 +15,7 @@ func _physics_process(delta):
 	if shoot_towards:
 		if detach_from_parent:
 			get_parent().remove_child(self)
-			get_tree().get_root().add_child(self)
+			get_tree().current_scene.add_child(self)
 		go_towards_point(delta)
 
 func go_towards_point(delta):

--- a/ActionLevels/LevelCreator/Enemies/Gunnerfly/Gunnerfly.gd
+++ b/ActionLevels/LevelCreator/Enemies/Gunnerfly/Gunnerfly.gd
@@ -39,7 +39,7 @@ func _shoot():
 		_gunshot.belongs_to_player = false
 		_gunshot.move_rightward = false
 		_gunshot.set_bullet_type(default_shooting_angle)
-		get_tree().get_root().add_child(_gunshot)
+		get_tree().current_scene.add_child(_gunshot)
 		_gunshot.position = parent_node.position + Vector2(-76,3)
 
 func start_flashing():

--- a/ActionLevels/LevelCreator/Enemies/StaticBroBear/StaticBroBear_logic.gd
+++ b/ActionLevels/LevelCreator/Enemies/StaticBroBear/StaticBroBear_logic.gd
@@ -46,7 +46,7 @@ func _on_fire_rate_timeout():
 		new_bullet.player_position = player_position
 		new_bullet.shoot_towards = true
 		new_bullet.speed = bullet.speed
-		get_tree().get_root().call_deferred("add_child", new_bullet)
+		get_tree().current_scene.call_deferred("add_child", new_bullet)
 		#launch_bullet(bullet)
 		has_fired = true
 		fire_again_timer.set_wait_time(1.0)

--- a/ActionLevels/LevelCreator/Enemies/StaticGunnerfly/StaticGunnerfly_logic.gd
+++ b/ActionLevels/LevelCreator/Enemies/StaticGunnerfly/StaticGunnerfly_logic.gd
@@ -69,7 +69,7 @@ func _on_fire_rate_timeout():
 		bullet.add_to_group("static_gunnerfly_bullets")
 		bullet.speed = projectile_speed
 		AudioManager.playSFX("gunshot", 1.0, -1.0)
-		get_tree().get_root().add_child(bullet)
+		get_tree().current_scene.add_child(bullet)
 		bullet.position = s.global_position
 		bullet.rotation = s.global_rotation
 		yield(get_tree().create_timer(0.3), "timeout")

--- a/Autoload/Events.gd
+++ b/Autoload/Events.gd
@@ -111,7 +111,6 @@ func transition_to_new_scene(next_scene):
 	self.emit_signal("transition_to_scene", next_scene, true)
 	
 func go_to_game_over():
-	print("transition to game over screen")
 	AudioManager.fade_out_music(1.0)
 	self.emit_signal("transition_to_scene", "GameOver", true)
 


### PR DESCRIPTION
Prevents weird game over states. e.g. Projectiles can still be on screen when the player retries the level.

Now, because they get put on the `current_scene` and not the tree root they should get thrown out when the user restarts the scene.

I also make the player invincible on the level start, until they press 'Enter', then they'll become un-invincible again.