### PR TITLE
[QoL] - Reduce hitbox size for UFO enemies

### DIFF
--- a/ActionLevels/LevelCreator/Enemies/BroBear/BroBear.tscn
+++ b/ActionLevels/LevelCreator/Enemies/BroBear/BroBear.tscn
@@ -12,7 +12,7 @@ _data = {
 }
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 141.25, 209 )
+extents = Vector2( 141.25, 165 )
 
 [node name="BroBear" type="Node2D" groups=["non_queue_free_rotator"]]
 position = Vector2( 928, 429 )
@@ -42,7 +42,8 @@ speed_scale = 2.0
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Path2D/PathFollow2D/Area2D"]
-position = Vector2( -6.25, -16 )
+position = Vector2( -6.25, -25 )
+scale = Vector2( 1, 1 )
 shape = SubResource( 2 )
 
 [node name="VisibilityNotifier2D" type="VisibilityNotifier2D" parent="Path2D/PathFollow2D/Area2D"]

--- a/ActionLevels/LevelCreator/Enemies/BroBun/BroBun.tscn
+++ b/ActionLevels/LevelCreator/Enemies/BroBun/BroBun.tscn
@@ -12,7 +12,7 @@ _data = {
 }
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 141.25, 209 )
+extents = Vector2( 141.25, 156.25 )
 
 [node name="BroBun" type="Node2D" groups=["non_queue_free_rotator"]]
 position = Vector2( 928, 429 )
@@ -42,7 +42,8 @@ speed_scale = 2.0
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Path2D/PathFollow2D/Area2D"]
-position = Vector2( -6.25, -16 )
+position = Vector2( -6.25, -11.25 )
+scale = Vector2( 1, 1 )
 shape = SubResource( 2 )
 
 [node name="VisibilityNotifier2D" type="VisibilityNotifier2D" parent="Path2D/PathFollow2D/Area2D"]

--- a/ActionLevels/LevelCreator/Enemies/StaticBroBear/StaticBroBear.tscn
+++ b/ActionLevels/LevelCreator/Enemies/StaticBroBear/StaticBroBear.tscn
@@ -13,7 +13,7 @@ _data = {
 }
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 141.25, 209 )
+extents = Vector2( 141.25, 158.75 )
 
 [node name="StaticBroBear" type="Node2D"]
 position = Vector2( 1843, 92 )
@@ -50,7 +50,8 @@ speed_scale = 2.0
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Path2D/PathFollow2D/Area2D"]
-position = Vector2( -6.25, -16 )
+position = Vector2( -6.25, -6.25 )
+scale = Vector2( 1, 1 )
 shape = SubResource( 2 )
 
 [node name="Rotator" type="Node2D" parent="."]


### PR DESCRIPTION
These guys have had it TOO GOOD FOR TOO LONG

So bloody annoying when you're trying pacifist and you THINK you can jump over them and then their MASSIVE ASS HITBOX hurts you anyway.

- Reduces size of the hitbox for UFO enemies. The top of their head won't hurt you and the flame on the bottom of the UFO won't either.