### PR TITLE
[QoL/Bug Fix] Add disable pause functionality

### DIFF
--- a/ActionLevels/Level1/Level1_Forest.gd
+++ b/ActionLevels/Level1/Level1_Forest.gd
@@ -19,6 +19,7 @@ var first_run : bool
 
 func _ready():
 	randomize()
+	Events.emit_signal("pausing_allowed", false)
 	var level_stats : Resource = LevelStats.new()
 	level_stats.level_name = 'Level1_Forest'
 	level_stats.level_number = 1
@@ -61,6 +62,7 @@ func _on_boss_spawn():
 	AudioManager.play_music("level1_boss")
 
 func _on_confirm_level_start():
+	Events.emit_signal("pausing_allowed", true)
 	AudioManager.playSFX("ui_confirm")
 	enemy_spawner.start_enemy_spawner()
 	platform_spawner.start_platform_spawner()

--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventBoss.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_EventBoss.gd
@@ -169,6 +169,7 @@ func _on_big_bird_boss_defeated(death_position):
 	end_event()
 
 func _on_pacifist_successful():
+	Events.emit_signal("pausing_allowed", false)
 	AudioManager.fade_out_music(3)
 	collectible_spawn_timer.stop()
 	Events.emit_signal("disable_player_action", true)

--- a/Autoload/Events.gd
+++ b/Autoload/Events.gd
@@ -71,6 +71,9 @@ signal background_moving_enabled(enabled)
 signal fall_down_ui
 signal go_up_ui
 
+# pausing
+signal pausing_allowed(pause_allowed)
+
 # save file location and metadata
 const SAVE_FILE_LOCATION : String = "res://mggsave.save"
 const COMPLETED_LEVELS : Array = []

--- a/HUD/PauseMenuGameplay.gd
+++ b/HUD/PauseMenuGameplay.gd
@@ -11,18 +11,23 @@ onready var spinny_star_resume = get_node("%SpinnyStarResume")
 onready var spinny_star_retry = get_node("%SpinnyStarRetry")
 onready var spinny_star_title = get_node("%SpinnyStarTitle")
 
-
 onready var vhs_filter = get_node_or_null(vhs_filter_path)
 
+var pausing_allowed : bool = true
+
 func _ready():
+	Events.connect("pausing_allowed", self, "_on_pausing_allowed")
 	if vhs_filter == null:
 		print("Could not find a node named VHS filter in this scene!")
 	var parent_node = self.get_parent()
 	if parent_node.name == "Bedroom":
 		retry_button.visible = false
 
+func _on_pausing_allowed(pause_allowed: bool):
+	pausing_allowed = pause_allowed
+
 func _unhandled_input(event):
-	if event.is_action_pressed("paused"):
+	if event.is_action_pressed("paused") and pausing_allowed:
 		self.is_paused = !is_paused
 
 func set_is_paused(value):


### PR DESCRIPTION
Noticed this when testing the pacifist route.

If you pause the game when there's a dialogue box open you lose focus of the dialogue box and have to manually click on it to get the focus back.

I spent some time trying to figure out how to "refocus" after resuming the game but instead decided for the simpler route -- just disable pausing in some situations.

Bit of a hack but the only dialogue that doesn't auto advance is the dialogue we have at the end of the game.
I also decided to disable it until the stage actually starts when you press enter.