### PR TITLE
[Bug fix] - Weird slide animation while jumping

### DIFF
--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=243 format=2]
+[gd_scene load_steps=240 format=2]
 
 [ext_resource path="res://imported_assets/actors/mg/Player_MeleeTEST-A.png" type="Texture" id=1]
 [ext_resource path="res://Player/Player.gd" type="Script" id=2]
@@ -661,8 +661,6 @@ auto_advance = true
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=254]
 
-[sub_resource type="AnimationNodeStateMachineTransition" id=256]
-
 [sub_resource type="AnimationNodeStateMachineTransition" id=257]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=448]
@@ -684,9 +682,9 @@ states/Run/node = SubResource( 53 )
 states/Run/position = Vector2( -369.875, -110.023 )
 states/Slide/node = SubResource( 249 )
 states/Slide/position = Vector2( 200.3, -109.547 )
-transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 239 ), "AboutToFall", "Landing", SubResource( 240 ), "Run", "Slide", SubResource( 253 ), "Slide", "RisingLoop", SubResource( 254 ), "Landing", "Slide", SubResource( 256 ), "Slide", "Run", SubResource( 257 ), "Run", "JustStanding", SubResource( 448 ), "JustStanding", "Run", SubResource( 470 ) ]
+transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 239 ), "AboutToFall", "Landing", SubResource( 240 ), "Run", "Slide", SubResource( 253 ), "Slide", "RisingLoop", SubResource( 254 ), "Slide", "Run", SubResource( 257 ), "Run", "JustStanding", SubResource( 448 ), "JustStanding", "Run", SubResource( 470 ) ]
 start_node = "Run"
-graph_offset = Vector2( -958.023, -186.828 )
+graph_offset = Vector2( -645.07, -186.828 )
 
 [sub_resource type="AnimationNodeStateMachinePlayback" id=128]
 
@@ -1198,8 +1196,6 @@ node_connections = [ "TimeScale", 0, "Animation", "output", 0, "TimeScale" ]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=269]
 
-[sub_resource type="AnimationNodeStateMachineTransition" id=270]
-
 [sub_resource type="AnimationNodeStateMachineTransition" id=467]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=471]
@@ -1220,9 +1216,9 @@ states/Run/node = SubResource( 53 )
 states/Run/position = Vector2( -406.5, -84.0534 )
 states/Slide/node = SubResource( 266 )
 states/Slide/position = Vector2( 117.315, -88.559 )
-transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 241 ), "AboutToFall", "Landing", SubResource( 242 ), "Run", "Slide", SubResource( 267 ), "Slide", "Run", SubResource( 268 ), "Slide", "RisingLoop", SubResource( 269 ), "Landing", "Slide", SubResource( 270 ), "Run", "JustStanding", SubResource( 467 ), "JustStanding", "Run", SubResource( 471 ) ]
+transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 241 ), "AboutToFall", "Landing", SubResource( 242 ), "Run", "Slide", SubResource( 267 ), "Slide", "Run", SubResource( 268 ), "Slide", "RisingLoop", SubResource( 269 ), "Run", "JustStanding", SubResource( 467 ), "JustStanding", "Run", SubResource( 471 ) ]
 start_node = "Run"
-graph_offset = Vector2( -958.904, -128.604 )
+graph_offset = Vector2( -715.232, -128.604 )
 
 [sub_resource type="AnimationNodeStateMachinePlayback" id=197]
 
@@ -1744,8 +1740,6 @@ node_connections = [ "TimeScale", 0, "Animation", "output", 0, "TimeScale" ]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=276]
 
-[sub_resource type="AnimationNodeStateMachineTransition" id=277]
-
 [sub_resource type="AnimationNodeStateMachineTransition" id=469]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=472]
@@ -1766,9 +1760,9 @@ states/Run/node = SubResource( 53 )
 states/Run/position = Vector2( -470.5, -41.6773 )
 states/Slide/node = SubResource( 273 )
 states/Slide/position = Vector2( 152.259, -26.243 )
-transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 243 ), "AboutToFall", "Landing", SubResource( 244 ), "Run", "Slide", SubResource( 274 ), "Slide", "Run", SubResource( 275 ), "Slide", "RisingLoop", SubResource( 276 ), "Landing", "Slide", SubResource( 277 ), "Run", "JustStanding", SubResource( 469 ), "JustStanding", "Run", SubResource( 472 ) ]
+transitions = [ "Run", "RisingLoop", SubResource( 54 ), "RisingLoop", "AboutToFall", SubResource( 55 ), "AboutToFall", "FallingLoop", SubResource( 56 ), "FallingLoop", "Landing", SubResource( 57 ), "Landing", "Run", SubResource( 58 ), "RisingLoop", "Landing", SubResource( 243 ), "AboutToFall", "Landing", SubResource( 244 ), "Run", "Slide", SubResource( 274 ), "Slide", "Run", SubResource( 275 ), "Slide", "RisingLoop", SubResource( 276 ), "Run", "JustStanding", SubResource( 469 ), "JustStanding", "Run", SubResource( 472 ) ]
 start_node = "Run"
-graph_offset = Vector2( -908.806, -99.497 )
+graph_offset = Vector2( -686.756, -99.497 )
 
 [sub_resource type="AnimationNodeStateMachinePlayback" id=236]
 
@@ -1800,7 +1794,6 @@ shape = SubResource( 3 )
 
 [node name="ColorSparkles" type="AnimatedSprite" parent="."]
 position = Vector2( -191.428, 240 )
-scale = Vector2( 1, 1 )
 frames = SubResource( 494 )
 animation = "On"
 playing = true
@@ -1871,8 +1864,7 @@ parameters/Slide/TimeScale/scale = 1.0
 [node name="StaffDown" type="AnimatedSprite" parent="."]
 visible = false
 frames = SubResource( 228 )
-animation = "run"
-frame = 9
+animation = "just_standing"
 __meta__ = {
 "_edit_group_": true,
 "_edit_lock_": true


### PR DESCRIPTION
Animation tree my beloved.

When landing the player would automatically transition to sliding for some reason.

I removed the connection from "Landing -> Slide". Hopefully shouldn't cause too many issues but it means you can't immediately go from landing to slide on frame 1, but you can still slide from "Run" (the default state) that takes place after "Landing" so I don't think the change is super noticable, tested it myself and it seemed alright although I'll be honest I don't use slide that much when playing myself.