### PR TITLE
Add winner crown and fix small bug in gunnerfly

### DIFF
--- a/ActionLevels/LevelCreator/Enemies/StaticGunnerfly/StaticGunnerfly_logic.gd
+++ b/ActionLevels/LevelCreator/Enemies/StaticGunnerfly/StaticGunnerfly_logic.gd
@@ -79,6 +79,9 @@ func _fire_rate_timer_setup():
 	self.add_child(fire_rate_timer)
 
 func _on_fire_rate_timeout():
+	if parent_node.health_value <= 0:
+		return
+
 	for s in rotator.get_children():
 		var bullet = gunnerfly_bullet.instance()
 		bullet.add_to_group("static_gunnerfly_bullets")

--- a/Menus/MainMenu.gd
+++ b/Menus/MainMenu.gd
@@ -8,6 +8,8 @@ onready var star_select_credits = get_node("%StarSelectCredits")
 onready var star_select_room = get_node("%StarSelectRoom")
 onready var star_select_fullscreen = get_node("%StarSelectFullscreen")
 
+onready var winner_crown = get_node("%WinnerCrown")
+
 onready var title_screen_animation = get_node("%TitleScreenAnimation")
 onready var camera = get_node("%Camera2D")
 onready var tween = get_node("%Tween")
@@ -59,8 +61,13 @@ func _ready():
 		room_button.disabled = false
 	AudioManager.play_music("main_menu")
 	credits_menu.visible = false
-	
+	title_screen_animation.connect("animation_finished", self, "_on_characters_appear_finished")
 	title_screen_animation.play("characters_appear")
+
+func _on_characters_appear_finished(anim_name):
+	var real_gamer : bool = SaveFileManager.get_beaten_first_level_before() and SaveFileManager.get_all_dogs_collected()
+	if real_gamer:
+		winner_crown.visible = true
 
 func _process(delta):
 	if (title_screen_animation.is_playing() or tween.is_active() or !camera_timer.is_stopped()) and Input.is_action_just_pressed("ui_accept"):
@@ -140,25 +147,20 @@ func _on_CreditsButton_pressed():
 	credits_menu.visible = true
 	credits_hide_button.grab_focus()
 
-
 func _on_CreditsButton_focus_entered():
 	AudioManager.playSFX("ui_hover")
 	star_select_credits.visible = true
 
-
 func _on_CreditsButton_focus_exited():
 	star_select_credits.visible = false
 
-
 func _on_CreditsButton_mouse_entered():
 	credits_button.grab_focus()
-
 
 func _on_CreditsHideButton_pressed():
 	credits_menu.visible = false
 	delete_save_panel.visible = false
 	credits_button.grab_focus()
-
 
 func activate_cheat_code():
 	if not cheat_code_activated:
@@ -187,19 +189,14 @@ func _input(event):
 		if cheat_code_detection.join("") == successful_cheat_code:
 			activate_cheat_code()
 
-
 func play_sound(sound_key : String, volume : float):
 	AudioManager.playSFX(sound_key, 1.0, volume)
-	
-
 
 func _on_FullscreenCheckbox_toggled(button_pressed):
 	if button_pressed:
 		OS.window_fullscreen = true
 	else:
 		OS.window_fullscreen = false
-
-
 
 ## Delete Save
 func _on_DeleteSaveButton_pressed():
@@ -213,7 +210,6 @@ func _on_DeleteSaveButton_pressed():
 	$"%NoDeleteButton".show()
 
 func _on_YesDeleteButton_pressed():
-	#TODO: Actually delete file lol.
 	SaveFileManager.reset_save_file()
 	AudioManager.playSFX("player_damage")
 	$"%AreYouSureLabel".text ="\nSave Data Deleted."
@@ -224,7 +220,6 @@ func _on_YesDeleteButton_pressed():
 	room_button.disabled = true
 	delete_save_panel.visible = false
 
-
 func _on_NoDeleteButton_pressed():
 	delete_save_panel.visible = false
 
@@ -234,7 +229,6 @@ func _on_YesDeleteButton_focus_entered():
 
 func _on_NoDeleteButton_focus_entered():
 	AudioManager.playSFX("ui_hover")
-
 
 func _on_FullscreenCheckbox_focus_entered():
 	AudioManager.playSFX("ui_hover")

--- a/Menus/MainMenu.tscn
+++ b/Menus/MainMenu.tscn
@@ -627,6 +627,7 @@ frequency = 2.0
 amplitude = 0.1
 
 [node name="WinnerCrown" parent="CharacterLayer" instance=ExtResource( 9 )]
+unique_name_in_owner = true
 visible = false
 position = Vector2( 1390, 90.9999 )
 scale = Vector2( 0.55888, 0.55888 )


### PR DESCRIPTION
Display the winner crown after the title screen animation finishes if the player has beaten the game and collected all the dogs (Not sure if you wanted the crown to display if it was also all challenges? But easy fix to the logic if so)

Small bug fix also that I found while testing in Godot 4. Sometimes right after Gunnerfly dies it still has a chance to shoot. This is cause we don't check its health value when doing the shooting check so it can have an extra shot sometimes before being queue free'd. Small issue but reduces the chances of unfair deaths I guess.