### PR TITLE
[Balance] Reduce enemy spawn speed in final dog event

### DIFF
--- a/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event5.gd
+++ b/ActionLevels/LevelCreator/LevelEvents/Level1/Level1_Event5.gd
@@ -28,7 +28,7 @@ var background_element_speed = 100
 
 var num_background_elements_offscreen = 0
 
-var spawned_element_speed = 600
+var spawned_element_speed = 500
 
 # Timers
 onready var start_event_timer = Timer.new()


### PR DESCRIPTION
Merge this if you want otherwise fuhgeddaboudit

Reduces the speed of the enemies in the final dog event from 600 to 500.

Should theoretically make it a little bit easier